### PR TITLE
Suppress reject when killing CLI Emitter

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -79,6 +79,8 @@ export const cliHook = (emitter: CLIEmitter, callbacks: Callbacks): Promise<numb
         return emitter.proc.stdin.write(`${c}\n`);
       },
       kill: () => {
+        // suppress reject callback when CLI exits to prevent users
+        // from getting notified about it (purduesigbots/pros-cli-middeware#5)
         emitter.suppressExit = true;
         if (platform() === 'win32') {
           exec(`taskkill /pid ${emitter.proc.pid} /T /F`);


### PR DESCRIPTION
Prevent reject callback when killing the CLI via the CLIEmitter. 
This serves to suppress error notifications when the user aborts an operation.

- [x] No notification when cancelling the upload prompt