### PR TITLE
Add ProjectTracker

### DIFF
--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -45,11 +45,11 @@ export class ProjectTracker {
     return project;
   }
 
-get lastWeakProject(): string {
+  get lastWeakProject(): string {
     return this._last_weak_project;
   }
 
-get lastStrongProject(): string {
+  get lastStrongProject(): string {
     return this._last_strong_project;
   }
 

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -41,7 +41,7 @@ class ProjectTracker {
     }
     const project = this.findProject(path);
     this._last_weak_project = project;
-    if (project != null || strong) {
+    if (project !== null || strong) {
       this._last_strong_project = project;
     }
     return project;

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -12,6 +12,9 @@ export class ProjectTracker {
   }
 
   findProject(path: string, recurseTimes: number = 10): string {
+    if (!path) {
+      return null;
+    }
     path = _path.resolve(path);
     try {
       var stat = fs.lstatSync(path);
@@ -31,8 +34,10 @@ export class ProjectTracker {
   }
 
   visit(path: string, strong: boolean = false): string {
+    if (path) {
+      this._last_directory = _path.dirname(path);
+    }
     const project = this.findProject(path);
-    this._last_directory = _path.dirname(path);
     this._last_weak_project = project;
     if (project != null || strong) {
       this._last_strong_project = project;

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -45,7 +45,7 @@ export class ProjectTracker {
     return project;
   }
 
-  lastWeakProject(): string {
+get lastWeakProject(): string {
     return this._last_weak_project;
   }
 

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -1,0 +1,50 @@
+import * as _path from 'path';
+import * as fs from 'fs';
+
+export class ProjectTracker {
+  private _last_weak_project: string;
+  private _last_strong_project: string;
+
+  constructor() {
+    this._last_weak_project = null;
+    this._last_strong_project = null;
+  }
+
+  findProject(path: string, recurseTimes: number = 10): string {
+    path = _path.resolve(path);
+    try {
+      var stat = fs.lstatSync(path);
+      if (stat.isFile() && _path.basename(path) === 'project.pros') {
+        return _path.dirname(path);
+      } else if (stat.isDirectory()) {
+        if (fs.lstatSync(_path.join(path, "project.pros")).isFile()) {
+          return path;
+        }
+      }
+    } catch (e) { /* ignore */ }
+    if(recurseTimes > 0) {
+      return this.findProject(_path.dirname(path), recurseTimes - 1);
+    } else {
+      return null;
+    }
+  }
+
+  visit(path: string, strong: boolean = false): string {
+    const project = this.findProject(path);
+    this._last_weak_project = project;
+    if (project != null || strong) {
+      this._last_strong_project = project;
+    }
+    return project;
+  }
+
+  lastWeakProject(): string {
+    return this._last_weak_project;
+  }
+
+  lastStrongProject(): string {
+    return this._last_strong_project;
+  }
+}
+
+export const GlobalProjectTracker = new ProjectTracker();

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -49,7 +49,7 @@ get lastWeakProject(): string {
     return this._last_weak_project;
   }
 
-  lastStrongProject(): string {
+get lastStrongProject(): string {
     return this._last_strong_project;
   }
 

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -1,17 +1,19 @@
 import * as _path from 'path';
 import * as fs from 'fs';
 
+type NullableString = string | null;
+
 export class ProjectTracker {
-  private _last_weak_project: string;
-  private _last_strong_project: string;
-  private _last_directory: string;
+  private _last_weak_project: NullableString;
+  private _last_strong_project: NullableString;
+  private _last_directory: NullableString;
 
   constructor() {
     this._last_weak_project = null;
     this._last_strong_project = null;
   }
 
-  findProject(path: string, recurseTimes: number = 10): string {
+  findProject(path: NullableString, recurseTimes: number = 10): NullableString {
     if (!path) {
       return null;
     }
@@ -33,7 +35,7 @@ export class ProjectTracker {
     }
   }
 
-  visit(path: string, strong: boolean = false): string {
+  visit(path: NullableString, strong: boolean = false): NullableString {
     if (path) {
       this._last_directory = _path.dirname(path);
     }
@@ -45,11 +47,11 @@ export class ProjectTracker {
     return project;
   }
 
-  get lastWeakProject(): string {
+  get lastWeakProject(): NullableString {
     return this._last_weak_project;
   }
 
-  get lastStrongProject(): string {
+  get lastStrongProject(): NullableString {
     return this._last_strong_project;
   }
 

--- a/src/ProjectTracker.ts
+++ b/src/ProjectTracker.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 export class ProjectTracker {
   private _last_weak_project: string;
   private _last_strong_project: string;
+  private _last_directory: string;
 
   constructor() {
     this._last_weak_project = null;
@@ -31,6 +32,7 @@ export class ProjectTracker {
 
   visit(path: string, strong: boolean = false): string {
     const project = this.findProject(path);
+    this._last_directory = _path.dirname(path);
     this._last_weak_project = project;
     if (project != null || strong) {
       this._last_strong_project = project;
@@ -44,6 +46,10 @@ export class ProjectTracker {
 
   lastStrongProject(): string {
     return this._last_strong_project;
+  }
+
+  lastDirectory(): string {
+    return this._last_directory;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './pros';
 export * from './types';
 export * from './v5';
 export * from './interactive';
+export * from './ProjectTracker';

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,14 +1,19 @@
 import { CLIEmitter, cliHook, getVersion } from './util';
-import { Callbacks, UnsupportedVersionException, UpdateProjectInteractiveOptions, UploadInteractiveOptions } from './types';
+import { Callbacks, UnsupportedVersionException, NewProjectInteractiveOptions, UpdateProjectInteractiveOptions, UploadInteractiveOptions } from './types';
 import { gt } from 'semver';
+import { GlobalProjectTracker } from './ProjectTracker';
 
-export const createNewProjectInteractive = async (callbacks: Callbacks): Promise<number> => {
+export const createNewProjectInteractive = async (callbacks: Callbacks, { directory }: NewProjectInteractiveOptions = {}): Promise<number> => {
   const cliVersion = await getVersion();
   if (gt(cliVersion, '3.1.3')) { // TODO: Make this the right version comparison
+    if (directory === undefined) {
+      directory = GlobalProjectTracker.lastDirectory();
+    }
+    const directoryStr = directory ? `--directory "${directory}"` : '';
     return cliHook(
       new CLIEmitter(
         'prosv5', [
-          'interactive', 'new_project'
+          'interactive', 'new_project', directoryStr
         ].filter(e => e !== '')
       ), callbacks
     );
@@ -20,6 +25,9 @@ export const createNewProjectInteractive = async (callbacks: Callbacks): Promise
 export const updateProjectInteractive = async (callbacks: Callbacks, { project }: UpdateProjectInteractiveOptions = {}): Promise<number> => {
   const cliVersion = await getVersion();
   if (gt(cliVersion, '3.1.3')) { // TODO: Make this the right version comparison
+    if (project === undefined) {
+      project = GlobalProjectTracker.lastWeakProject();
+    }
     const projectStr = project ? `--project "${project}"` : '';
     return cliHook(
       new CLIEmitter(
@@ -36,6 +44,9 @@ export const updateProjectInteractive = async (callbacks: Callbacks, { project }
 export const uploadInteractive = async (callbacks: Callbacks, { project }: UploadInteractiveOptions = {}): Promise<number> => {
   const cliVersion = await getVersion();
   if (gt(cliVersion, '3.1.3')) { // TODO: Make this the right version comparison
+    if (project === undefined) {
+      project = GlobalProjectTracker.lastWeakProject();
+    }
     const projectStr = project ? `--project "${project}"` : '';
     return cliHook(
       new CLIEmitter(

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -26,7 +26,7 @@ export const updateProjectInteractive = async (callbacks: Callbacks, { project }
   const cliVersion = await getVersion();
   if (gt(cliVersion, '3.1.3')) { // TODO: Make this the right version comparison
     if (project === undefined) {
-      project = GlobalProjectTracker.lastWeakProject();
+      project = GlobalProjectTracker.lastWeakProject;
     }
     const projectStr = project ? `--project "${project}"` : '';
     return cliHook(
@@ -45,7 +45,7 @@ export const uploadInteractive = async (callbacks: Callbacks, { project }: Uploa
   const cliVersion = await getVersion();
   if (gt(cliVersion, '3.1.3')) { // TODO: Make this the right version comparison
     if (project === undefined) {
-      project = GlobalProjectTracker.lastWeakProject();
+      project = GlobalProjectTracker.lastWeakProject;
     }
     const projectStr = project ? `--project "${project}"` : '';
     return cliHook(

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export type UploadProjectOptions = Partial<{run: boolean, name: string, slot: nu
 
 export type V5RemoveFileOptions = Partial<{all: boolean}>;
 
+export type NewProjectInteractiveOptions = Partial<{directory: string}>;
 export type UpdateProjectInteractiveOptions = Partial<{project: string}>;
 export type UploadInteractiveOptions = Partial<{project: string}>;
 


### PR DESCRIPTION
Adds a project tracker to the middleware to let editors keep track of when they visit PROS projects so they can be defaulted when uploading/upgrading/creating a new project.